### PR TITLE
Expose `useCdts`, so hosted-app can access WET context and its internals

### DIFF
--- a/packages/wet-boew-react/src/index.ts
+++ b/packages/wet-boew-react/src/index.ts
@@ -10,6 +10,7 @@ export {
   SplashContent,
   SplashTop,
   Top,
+  useCdts,
   AfterCdts,
 } from "./cdts";
 export { Language, useLanguage, useLngLinks } from "./language";


### PR DESCRIPTION
Currently, we are only exporting a handful of cdts-related internals, such as the Footer and the cdtsProvider. While the provider does expose all the bare-bones internals necessary to use the lib, if you need to reference it or consume a wet value, it's currently not possible (or at least not possibly in a non-hackish way).

This teeny-tiny PR just exposes this hook to be used by the client and so we have direct access to wet/cdts variables.